### PR TITLE
fixed deferral issue

### DIFF
--- a/server/sv_main.lua
+++ b/server/sv_main.lua
@@ -119,6 +119,7 @@ AddEventHandler('playerDropped', function () TriggerClientEvent("dz-admin:client
 AddEventHandler('playerConnecting', function(user, kickr, deferrals)
     LoadBans()
     deferrals.defer()
+    Wait(0)
     deferrals.update("[dz-admin | dz-security.live] Welcome to "..DZ.ServerName..", Your info is being checked.")
     local src = source
     local Identifier = GetPlayerIdentifiers(src)[1]


### PR DESCRIPTION
As you can see in the [fivem docs](https://docs.fivem.net/docs/scripting-reference/events/list/playerConnecting/) doing a `Wait(0)` is mandatory, or it breaks other resources doing deferrals.